### PR TITLE
use node16 Actions runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: Query to use to search for matching issues
     required: true
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
`node12` Actions runtime is deprecated by `node16`